### PR TITLE
build: common CMakeLists to rule them all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,110 +1,18 @@
-#[=[
+cmake_minimum_required(VERSION 3.5)
 
-*THIS CMakeLists.txt IS NO LONGER USED** 
+project(esi-opticks VERSION 0.1.0)
 
-Opticks CMake Conventions (STILL APPLY)
-=========================================
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
-1. project names are the same as the library targets they generate 
-2. project names are CamelCased, project directory names are lowercase
-3. lowercased project names match the names of their directories
-4. every CMake project command should be followed by "include(OpticksBuildOptions)"
-5. the name of every project should be set via a "name" variable : this is used within
-   the OpticksBuildOptions to set the install location of headers as include/${name}
-
-For example a project called DemoProj would be setup in demoproj subdirectory with
-a CMakeLists.txt file starting::
-
-    cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-    set(name DemoProj)
-    project(${name} VERSION 0.1.0)
-    include(OpticksBuildOptions)
-
-
-DECISION TO HALT ATTEMPTS TO GET INTEGRATED BUILD OPERATIONAL AGAIN
----------------------------------------------------------------------
-
-Because it doesnt add enough value for the effort, instead 
-just use proj-by-proj integrated at bash level with om.bash, 
-see om-install
-
-This Integrated Build  : ON HOLD
-------------------------------------
-
-For this integrated build, find_package is redefined by the below
-macro to skip packages corresponding to the below SUBDIRS as they have directly 
-been built already within the single CMake context and hence do not need to be found.
-
-This structure allows the proj-by-proj building and integrated building to otherwise
-be identical.
-
-bcm_ignore_package
-~~~~~~~~~~~~~~~~~~~
-
-Incase decide to try again with integrated build, try 
-out the bcm_ignore_package approach:
-
-* http://bcm.readthedocs.io/en/latest/src/Building.html#integrated-builds
-
-
-
-#]=]
-
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-set(name Opticks)
-project(${name} VERSION 0.1.0)
-include(OpticksBuildOptions)   
-
-set(INTEGRATED_SUBDIRS
-  okconf
-  sysrap
-#[=[
-  boostrap
-  npy
-  optickscore
-  ggeo 
-  assimprap
-  openmeshrap 
-  opticksgeo 
-  cudarap
-  thrustrap
-  optixrap
-  okop
-  oglrap  
-  opticksgl
-  ok
-  cfg4
-  okg4
-#]=]
-)
-
-
-macro(find_package)    
-   set(_args "${ARGV}")
-   set(_pkg ${ARGV0}) 
-   string(TOLOWER ${_pkg} _subdir) 
-   if(NOT "${_subdir}" IN_LIST INTEGRATED_SUBDIRS)
-       _find_package(${ARGV})   
-       set(_pkg_found ${${_pkg}_FOUND})
-       if(NOT ${_pkg} STREQUAL "BCM")  
-           message(STATUS "find_package ( ${ARGV} ) --> ${_pkg_found} ")
-       endif()
-       if(NOT "QUIET" IN_LIST _args AND NOT ${_pkg_found})
-           message(FATAL_ERROR "ABORT : failed to find non-QUIET pkg ${_pkg} ")
-       endif()
-   else()
-       #set(_tgt "Opticks::${_pkg}")
-       #
-       ## BEFORE so changes to headers in build directory take precedence 
-       ## over any old installed headers 
-       ##target_include_directories( ${_tgt} BEFORE INTERFACE  
-       #    $<BUILD_INTERFACE:${${_pkg}_SOURCE_DIR}>
-       #    $<BUILD_INTERFACE:${${_pkg}_BINARY_DIR}/inc>
-       #) 
-   endif()
-endmacro()
-
-foreach(_dir ${INTEGRATED_SUBDIRS})
-   add_subdirectory(${_dir})
-endforeach()
+add_subdirectory(okconf)
+add_subdirectory(sysrap)
+add_subdirectory(ana)
+add_subdirectory(analytic)
+add_subdirectory(bin)
+add_subdirectory(CSG)
+add_subdirectory(qudarap)
+add_subdirectory(CSGOptiX)
+add_subdirectory(gdxml)
+add_subdirectory(u4)
+add_subdirectory(g4cx)
 

--- a/CSG/CMakeLists.txt
+++ b/CSG/CMakeLists.txt
@@ -4,7 +4,6 @@ project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions NO_POLICY_SCOPE)
 
 find_package(CUDA REQUIRED) 
-find_package(SysRap REQUIRED)
 
 include_directories(
     ${CUDA_INCLUDE_DIRS}

--- a/CSGOptiX/CMakeLists.txt
+++ b/CSGOptiX/CMakeLists.txt
@@ -4,8 +4,6 @@ project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions)
 
 find_package(CUDA REQUIRED)   
-find_package(QUDARap REQUIRED)
-find_package(CSG REQUIRED)
 
 set(OpticksOptiX_VERBOSE ON)
 find_package(OpticksOptiX REQUIRED MODULE)   
@@ -122,6 +120,7 @@ WITH_THRUST compile definition
 target_compile_definitions( ${name} PRIVATE WITH_THRUST )
 
 target_include_directories( ${name} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/sysrap/inc>
     $<INSTALL_INTERFACE:include>
     $<INSTALL_INTERFACE:include/CSGOptiX>
 )

--- a/ana/tests/CMakeLists.txt
+++ b/ana/tests/CMakeLists.txt
@@ -4,8 +4,6 @@ project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions)
 
 
-find_package(SysRap REQUIRED CONFIG)
-
 set(TEST_SOURCES
     AnaTest.cc
 )

--- a/analytic/tests/CMakeLists.txt
+++ b/analytic/tests/CMakeLists.txt
@@ -4,8 +4,6 @@ project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions)
 
 
-find_package(SysRap REQUIRED CONFIG)
-
 set(TEST_SOURCES
     AnalyticTest.cc
 )

--- a/bin/tests/CMakeLists.txt
+++ b/bin/tests/CMakeLists.txt
@@ -4,8 +4,6 @@ project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions)
 
 
-find_package(SysRap REQUIRED CONFIG)
-
 set(TEST_SOURCES
     BinTest.cc
 )

--- a/g4cx/CMakeLists.txt
+++ b/g4cx/CMakeLists.txt
@@ -11,8 +11,6 @@ G4CX
 #]=]
 
 #find_package(Custom4 CONFIG)   # hmm U4 looks for Custom4 and does setup
-find_package(U4       REQUIRED CONFIG)
-find_package(CSGOptiX REQUIRED CONFIG)
 
 message(STATUS "${CMAKE_CURRENT_LIST_FILE} : Custom4_FOUND      : ${Custom4_FOUND}")
 message(STATUS "${CMAKE_CURRENT_LIST_FILE} : Custom4_VERSION    : ${Custom4_VERSION}")
@@ -40,6 +38,7 @@ target_link_libraries( ${name} PUBLIC
 
 target_include_directories( ${name} PUBLIC 
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
+   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/CSGOptiX>
 )
 
 target_compile_definitions( ${name} PUBLIC OPTICKS_G4CX )

--- a/gdxml/CMakeLists.txt
+++ b/gdxml/CMakeLists.txt
@@ -13,7 +13,6 @@ include(OpticksBuildOptions NO_POLICY_SCOPE)
 #set(G4_VERBOSE YES)
 #set(OpticksXercesC_VERBOSE YES)
 
-find_package(SysRap REQUIRED CONFIG)
 find_package(G4 REQUIRED MODULE)   # may be needed at CMake level only to find G4Persistency target for consistent XercesC version
 find_package(OpticksXercesC REQUIRED MODULE)
 

--- a/qudarap/CMakeLists.txt
+++ b/qudarap/CMakeLists.txt
@@ -8,8 +8,6 @@ set(FLAGS_VERBOSE ON)
 
 set(LIBS  )
 
-
-find_package(SysRap REQUIRED CONFIG)
 set(LIBS ${LIBS} Opticks::SysRap)  
 
 

--- a/qudarap/tests/CMakeLists.txt
+++ b/qudarap/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ foreach(SRC ${TEST_SOURCES})
     get_filename_component(TGT ${SRC} NAME_WE)
     add_executable(${TGT} ${SRC})
     target_link_libraries(${TGT} QUDARap )
+    target_include_directories(${TGT} PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/sysrap/inc>)
     install(TARGETS ${TGT} DESTINATION lib)
 
     #add_test(${name}.${TGT} ${TGT})

--- a/sysrap/CMakeLists.txt
+++ b/sysrap/CMakeLists.txt
@@ -41,7 +41,6 @@ But as OpticksCSG.h updates are rare, For now just need to remember to generate 
 
 #]=]
 
-find_package(OKConf REQUIRED CONFIG)
 find_package(NLJSON REQUIRED MODULE)
 find_package(PLog   REQUIRED MODULE)
 find_package(OpticksCUDA REQUIRED MODULE)
@@ -670,6 +669,8 @@ endif()
 
 target_include_directories( ${name} PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/okconf>
+   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/okconf/inc>
    $<INSTALL_INTERFACE:include>
    $<INSTALL_INTERFACE:include/SysRap>
    ${CUDA_INCLUDE_DIRS}

--- a/u4/CMakeLists.txt
+++ b/u4/CMakeLists.txt
@@ -18,12 +18,10 @@ include(OpticksBuildOptions NO_POLICY_SCOPE)
 
 message(STATUS "${CMAKE_CURRENT_LIST_FILE} : ====== 0 ======= find SysRap, G4  ")
 
-find_package(SysRap REQUIRED CONFIG)
 find_package(G4 REQUIRED MODULE)
 
 message(STATUS "${CMAKE_CURRENT_LIST_FILE} : ====== 1 ======= find GDXML CLHEP OpticksXercesC ")
 
-find_package(GDXML REQUIRED CONFIG)
 find_package(CLHEP  REQUIRED CONFIG) 
 find_package(OpticksXercesC REQUIRED MODULE)
 

--- a/u4/tests/CMakeLists.txt
+++ b/u4/tests/CMakeLists.txt
@@ -139,7 +139,6 @@ set(U4HitTest_SOURCES
     U4HitTest.cc
 )
 
-find_package(CSG REQUIRED)
 set(TGT U4HitTest)
 add_executable(${TGT} ${U4HitTest_SOURCES})
 target_link_libraries(${TGT} U4 Opticks::CSG)


### PR DESCRIPTION
With these changes the entire package (the min useful sub-packages) can be built as:

```
cmake -S esi-opticks -B build
cmake --build build
```