### PR TITLE
build: switch to shared plog instance

### DIFF
--- a/sysrap/CMakeLists.txt
+++ b/sysrap/CMakeLists.txt
@@ -738,7 +738,7 @@ target_compile_definitions( ${name}
 
       OPTICKS_SYSRAP 
       WITH_CHILD
-      PLOG_LOCAL
+      PLOG_GLOBAL
       $<$<CONFIG:Debug>:DEBUG_TAG>
       $<$<CONFIG:Debug>:DEBUG_PIDX>
       $<$<CONFIG:Debug>:DEBUG_PIDXYZ>


### PR DESCRIPTION
For easier control from the driving program.