### PR TITLE
explicitly enable experimental features in newer version of GLM

### DIFF
--- a/CSG/CSGFoundry.cc
+++ b/CSG/CSGFoundry.cc
@@ -8,6 +8,8 @@
 #include <csignal>
 #include <cstdlib>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/glm.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/CSG/CSGView.cc
+++ b/CSG/CSGView.cc
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <iomanip>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/gtx/transform.hpp>
 #include "NP.hh"
 #include "CSGView.h"

--- a/sysrap/SGLM.h
+++ b/sysrap/SGLM.h
@@ -112,6 +112,8 @@ Screen
 #include <string>
 #include <array>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/sysrap/s_tv.h
+++ b/sysrap/s_tv.h
@@ -12,6 +12,8 @@ s_tv.h : simple wrapper to give uniform behaviour to spa/sxf/sbb
 #include <sstream>
 #include <iomanip>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/glm.hpp>
 #include "glm/gtx/string_cast.hpp"
 #include <glm/gtx/transform.hpp>

--- a/sysrap/snd.cc
+++ b/sysrap/snd.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <csignal>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include "glm/glm.hpp"
 #include "glm/gtx/string_cast.hpp"
 #include <glm/gtx/transform.hpp>

--- a/sysrap/stra.h
+++ b/sysrap/stra.h
@@ -16,6 +16,8 @@ in new code.
 
 #include <array>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include "glm/glm.hpp"
 #include "glm/gtx/string_cast.hpp"
 #include <glm/gtx/transform.hpp>

--- a/sysrap/sxf.h
+++ b/sysrap/sxf.h
@@ -9,6 +9,8 @@ sxf.h : simple wrapper to give uniform behaviour to spa/sxf/sbb
 #include <sstream>
 #include <iomanip>
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/glm.hpp>
 #include "glm/gtx/string_cast.hpp"
 

--- a/u4/U4Transform.h
+++ b/u4/U4Transform.h
@@ -9,6 +9,8 @@
 #include "G4BooleanSolid.hh"
 #include "G4MultiUnion.hh"
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include "glm/gtx/string_cast.hpp"

--- a/u4/tests/U4TransformTest.cc
+++ b/u4/tests/U4TransformTest.cc
@@ -9,6 +9,8 @@
 #include "NP.hh"
 #include "strid.h"
 
+#define GLM_ENABLE_EXPERIMENTAL
+
 #include <glm/gtx/string_cast.hpp>
 
 


### PR DESCRIPTION
fix build error caused by Spack 0.23.0 upgrade 

define GLM_ENABLE_EXPERIMENTAL

```
8.392 In file included from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/glm-1.0.1-h4wgyipuf6wqsnlbnjhgudnl54bk5wiy/include/glm/gtx/string_cast.hpp:21,
8.392                  from /esi/opticks/sysrap/snd.cc:7:
8.392 /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/glm-1.0.1-h4wgyipuf6wqsnlbnjhgudnl54bk5wiy/include/glm/gtx/../gtx/dual_quaternion.hpp:24:9: error: #error "GLM: GLM_GTX_dual_quaternion is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
8.392    24 | #       error "GLM: GLM_GTX_dual_quaternion is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
8.392       |         ^~~~~
```