### PR TITLE
fix: partially revert 061c6333 as it applies to geant 11.2.2 only

### DIFF
--- a/u4/U4Surface.h
+++ b/u4/U4Surface.h
@@ -275,7 +275,7 @@ inline const std::vector<G4LogicalSkinSurface*>* U4Surface::PrepareSkinSurfaceVe
     }   
 
 #else
-    VKS* vec = tab;
+    const VKS* vec = tab;
 #endif
     return vec ; 
 }


### PR DESCRIPTION
See 061c6333:  fix: cannot push elements to const vector